### PR TITLE
fix(user_svc): 修复密码不一致是设置错误信息的panic

### DIFF
--- a/service/user/service/service.go
+++ b/service/user/service/service.go
@@ -34,16 +34,17 @@ func (g *Service) UserLogin(ctx context.Context, request *api.UserLoginRequest) 
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, status.Error(codes.Code(code.UserErrNotExistOrPassword.Code()), err.Error())
 		}
+		return nil, status.Error(codes.Code(code.UserErrLoginFailed.Code()), err.Error())
 	}
 
 	if userInfo.Password != request.Password {
-		return nil, status.Error(codes.Code(code.UserErrNotExistOrPassword.Code()), err.Error())
+		return nil, status.Error(codes.Code(code.UserErrNotExistOrPassword.Code()), code.UserErrNotExistOrPassword.Message())
 	}
 	//修改登录时间
 	userInfo.LastAt = time.Now().Unix()
 	_, err = g.ur.UpdateUser(userInfo)
 	if err != nil {
-		return nil, err
+		return nil, status.Error(codes.Code(code.UserErrLoginFailed.Code()), err.Error())
 	}
 
 	switch userInfo.Status {


### PR DESCRIPTION
**What this PR does / why we need it**:

修复密码不一致是设置错误信息的panic

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
